### PR TITLE
"sampler" is currently a keyword argument

### DIFF
--- a/qiskit_algorithms/optimizers/qnspsa.py
+++ b/qiskit_algorithms/optimizers/qnspsa.py
@@ -80,7 +80,7 @@ class QNSPSA(SPSA):
 
             # fidelity for estimation of the geometric tensor
             sampler = Sampler()
-            fidelity = QNSPSA.get_fidelity(ansatz, sampler)
+            fidelity = QNSPSA.get_fidelity(ansatz, "sampler"=sampler)
 
             # run QN-SPSA
             qnspsa = QNSPSA(fidelity, maxiter=300)


### PR DESCRIPTION
The example provided specifies the sampler option as if it would be positional, but it is actually a keyword argument. I don't understand the "*" or the possibility of the sampler to be None. But in order to make it work without removing those, the sampler hast to be especified as "sampler"=sampler.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Just updated the example provided in the docstring.

### Details and comments


